### PR TITLE
Update supported Python and Django versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,9 @@ sudo: false
 language: python
 python:
   - "2.7"
-  - "3.4"
   - "3.5"
   - "3.6"
   - "3.7"
+  - "3.8"
 install: pip install tox-travis
 script: tox

--- a/setup.py
+++ b/setup.py
@@ -76,7 +76,6 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',

--- a/tox.ini
+++ b/tox.ini
@@ -2,8 +2,7 @@
 envlist =
     {py36,py37,py38}-django-30
     {py35,py36,py37}-django-22
-    {py35,py36,py37}-django-21
-    {py27,py34,py35,py36,py37}-django-111
+    {py27,py35,py36,py37}-django-111
 
 [testenv]
 setenv =
@@ -11,9 +10,8 @@ setenv =
 commands = coverage run --source bootstrap_customizer runtests.py
 deps =
     django-111: Django>=1.11,<1.12
-    django-21: Django>=2.1,<2.2
     django-22: Django>=2.2,<3.0
-    django-30: Django>=3.0a1,<3.1
+    django-30: Django>=3.0,<3.1
     -r {toxinidir}/requirements.txt
     -r {toxinidir}/requirements_test.txt
 basepython =
@@ -21,5 +19,4 @@ basepython =
     py37: python3.7
     py36: python3.6
     py35: python3.5
-    py34: python3.4
     py27: python2.7


### PR DESCRIPTION
Updates supported Python and Django versions, adding Python 3.8 to
Travis and removing support for Python 3.4 and Django 2.1.